### PR TITLE
Color feature 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
+.idea/
 .cache
 dist
 node_modules
 .DS_Store
+yarn.lock

--- a/src/core/color.tsx
+++ b/src/core/color.tsx
@@ -1,0 +1,97 @@
+export class Color {
+  hex: string;
+
+  constructor(
+    hex: string
+  ) {
+    if (hex.length === 3) {
+      hex = hex + hex;
+    }
+
+    this.hex = hex;
+  }
+
+  lightenColor(color: string, percentage: number): string {
+    let r = Math.round(Math.min(255, parseInt(color.substring(1, 3), 16) * (1 + percentage))).toString(16);
+    let g = Math.round(Math.min(255, parseInt(color.substring(3, 5), 16) * (1 + percentage))).toString(16);
+    let b = Math.round(Math.min(255, parseInt(color.substring(5, 7), 16) * (1 + percentage))).toString(16);
+    return "#" + (r.length<2 ? "0" + r : r) + (g.length<2 ? "0" + g : g) + (b.length<2 ? "0" + b : b);
+  }
+
+  hexAlpha(alpha: number): string {
+    alpha = parseInt((alpha * 255).toFixed(0));
+
+    if (alpha <= 0) {
+      alpha = 0;
+    } else if (alpha >= 255) {
+      alpha = 255;
+    }
+
+    return this.hex + alpha.toString(16);
+  }
+
+  hexLighter(): string {
+    return this.hexAlpha(.7);
+  }
+
+  static default(): Color {
+    return new Color('#dedede');
+  }
+
+  static white(): Color {
+    return new Color('#ffffff');
+  }
+
+  static pink(): Color {
+    return new Color('#ffbefa');
+  }
+
+  static purple(): Color {
+    return new Color('#e2beff');
+  }
+
+  static brown(): Color {
+    return new Color('#c9a15f');
+  }
+
+  static red(): Color {
+    return new Color('#ffbebe');
+  }
+
+  static green(): Color {
+    return new Color('#c8ffc8');
+  }
+
+  static blue(): Color {
+    return new Color('#b6b6ff');
+  }
+
+  static cyan(): Color {
+    return new Color('#beffff');
+  }
+
+  static yellow(): Color {
+    return new Color('#ffffa1');
+  }
+
+  static magenta(): Color {
+    return new Color('#ffa6ff');
+  }
+
+  static orange(): Color {
+    return new Color('#ffcb99');
+  }
+
+  static black(): Color {
+    return new Color('#868686');
+  }
+
+  equals(color: Color): boolean {
+    return this.hex === color.hex;
+  }
+
+  isDefault(): boolean {
+    return this.equals(Color.default());
+  }
+
+}

--- a/src/core/range.ts
+++ b/src/core/range.ts
@@ -15,6 +15,10 @@ export class ByteRange {
     this.byteLength = byteLength;
   }
 
+  offset(): number {
+    return this.byteStart;
+  }
+
   size(): number {
     return this.byteLength;
   }
@@ -151,6 +155,14 @@ export class BitRange {
     this.buffer = buffer;
     this.bitStart = bitStart;
     this.bitLength = bitLength;
+  }
+
+  offset(): number {
+    return this.bitStart;
+  }
+
+  size(): number {
+    return this.bitLength;
   }
 
   enclosingByteRange(): ByteRange {

--- a/src/core/tree.tsx
+++ b/src/core/tree.tsx
@@ -1,10 +1,12 @@
 import { ByteRange, BitRange } from "./range";
+import { Color } from "./color";
 
 export class Tree {
   label: string;
   range: ByteRange | BitRange;
   children: Array<Tree>;
   error?: Error;
+  color: Color;
 
   parent?: Tree;
 
@@ -12,12 +14,14 @@ export class Tree {
     label: string,
     range: ByteRange | BitRange,
     children: Array<Tree> = [],
-    error?: Error
+    error?: Error,
+    color?: Color
   ) {
     this.label = label;
     this.range = range;
     this.children = children;
     this.error = error;
+    this.color = color || Color.default();
 
     // Set parent pointers for the children tree objects.
     for (let child of this.children) {
@@ -37,5 +41,11 @@ export class Tree {
 
   isParentOf(other: Tree): boolean {
     return other.isChildOf(this);
+  }
+
+  withColor(color: Color): Tree {
+    this.color = color;
+
+    return this;
   }
 }

--- a/src/inspectors/custom.tsx
+++ b/src/inspectors/custom.tsx
@@ -100,7 +100,7 @@ Object.assign(window, {
 });
 
 const DEFAULT_CODE = `((range) => {
-  return new Tree("Example Tree", range, []);
+  return new Tree("Example Tree", range, []).withColor(Color.red());
 })`;
 
 class CustomInspector extends React.Component<{}, CustomInspectorState> {

--- a/src/inspectors/custom.tsx
+++ b/src/inspectors/custom.tsx
@@ -1,5 +1,6 @@
 import { ByteRange, BitRange } from "../core/range";
 import { Tree } from "../core/tree";
+import { Color } from "../core/color";
 import { assert } from "chai";
 
 import * as React from "react";
@@ -93,6 +94,7 @@ Object.assign(window, {
   Tree: Tree,
   ByteRange: ByteRange,
   BitRange: BitRange,
+  Color: Color,
   opus: require("../decoders/opus"),
   rtp: require("../decoders/rtp")
 });

--- a/src/inspectors/png.tsx
+++ b/src/inspectors/png.tsx
@@ -6,6 +6,7 @@ import { assert } from "chai";
 import { ByteRange, BitRange } from "../core/range";
 import { SimpleInspector } from "../ui/simpleinspector";
 import { Tree } from "../core/tree";
+import { Color } from "../core/color";
 
 import { hexEllipsis } from "../core/utils";
 
@@ -91,20 +92,20 @@ function inspect(range: ByteRange): Tree {
         `Chunk (${type.readUTF8()})`,
         ptr.bytes(0, chunkSize),
         [
-          new Tree(`Length: ${byteLen}`, length),
-          new Tree(`Type: ${type.readUTF8()}`, type)
+          new Tree(`Length: ${byteLen}`, length).withColor(Color.blue()),
+          new Tree(`Type: ${type.readUTF8()}`, type).withColor(Color.orange())
         ]
           .concat(chunkElements)
-          .concat([new Tree(`CRC: ${crc.readUIntBE()}`, crc)])
-      )
+          .concat([new Tree(`CRC: ${crc.readUIntBE()}`, crc).withColor(Color.brown())])
+      ).withColor(Color.green())
     );
 
     ptr = ptr.bytes(chunkSize);
   }
 
   return new Tree("PNG Image", range, [
-    new Tree(`Signature: ${signature.toHex()}`, signature),
-    new Tree(`Chunks (${chunks.length})`, range.bytes(8), chunks)
+    new Tree(`Signature: ${signature.toHex()}`, signature).withColor(Color.red()),
+    new Tree(`Chunks (${chunks.length})`, range.bytes(8), chunks).withColor(Color.magenta())
   ]);
 }
 

--- a/src/ui/binaryview.tsx
+++ b/src/ui/binaryview.tsx
@@ -84,6 +84,10 @@ export class BinaryView extends React.Component<
   }
 
   byteColor(tree: Tree, byteNumber: number, color?: Color) {
+    if (tree === undefined) {
+      return Color.default();
+    }
+
     for (const t of tree.children) {
       if (t.range.offset() <= byteNumber && byteNumber <= (t.range.offset() + t.range.size())) {
         if (!t.color.isDefault()) {

--- a/src/ui/binaryview.tsx
+++ b/src/ui/binaryview.tsx
@@ -89,7 +89,7 @@ export class BinaryView extends React.Component<
     }
 
     for (const t of tree.children) {
-      if (t.range.offset() <= byteNumber && byteNumber <= (t.range.offset() + t.range.size())) {
+      if (t.range.offset() <= byteNumber && byteNumber < (t.range.offset() + t.range.size())) {
         if (!t.color.isDefault()) {
           color = t.color;
         }

--- a/src/ui/binaryview.tsx
+++ b/src/ui/binaryview.tsx
@@ -193,7 +193,7 @@ export class BinaryView extends React.Component<
                         }
                       }
 
-                      const byteNumber = i + (j * 8) + (k * 16);
+                      const byteNumber = i + (j * HEX_BYTES_PER_GROUP) + (k * HEX_BYTES_PER_ROW);
                       const color = this.byteColor(this.props.tree, byteNumber, undefined) || this.props.tree.color;
 
                       return (
@@ -257,7 +257,7 @@ export class BinaryView extends React.Component<
                             }
                           }
 
-                          const color = this.byteColor(this.props.tree, Math.floor(b.offset() / 8), undefined) || this.props.tree.color;
+                          const color = this.byteColor(this.props.tree, Math.floor(b.offset() / HEX_BYTES_PER_GROUP), undefined) || this.props.tree.color;
 
                           return (
                             <span

--- a/src/ui/treebinaryview.tsx
+++ b/src/ui/treebinaryview.tsx
@@ -16,8 +16,8 @@ export class TreeBinaryView extends React.Component<
     super(props);
     this.state = {};
   }
-
   render() {
+
     return (
       <>
         <Row style={{ maxHeight: "600px", marginTop: "10px" }}>
@@ -34,7 +34,9 @@ export class TreeBinaryView extends React.Component<
             </div>
           </Col>
           <Col md={6}>
+
             <BinaryView
+              tree={this.props.tree}
               data={this.props.data}
               selected={
                 this.state.selected ? this.state.selected.range : undefined

--- a/src/ui/treeview.tsx
+++ b/src/ui/treeview.tsx
@@ -97,7 +97,7 @@ export class TreeView extends React.Component<
                 icon={this.state.open ? faCaretDown : faCaretRight}
               />
             </span>
-            <span title={`Byte ${tree.range.offset()} to ${tree.range.offset() + tree.range.size()}`}>
+            <span title={`Byte range from ${tree.range.offset()} to ${tree.range.offset() + tree.range.size()}`}>
                 {tree.label}
             </span>
           </div>
@@ -117,7 +117,7 @@ export class TreeView extends React.Component<
       );
     } else {
       return (
-        <div title={`Byte ${tree.range.offset()} to ${tree.range.offset() + tree.range.size()}`}
+        <div title={`Byte range from ${tree.range.offset()} to ${tree.range.offset() + tree.range.size()}`}
           style={{
             backgroundColor,
             paddingLeft: "5px"

--- a/src/ui/treeview.tsx
+++ b/src/ui/treeview.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 
 import { ByteRange, BitRange } from "../core/range";
 import { Tree } from "../core/tree";
+import { Color } from "../core/color";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faCaretRight, faCaretDown } from "@fortawesome/free-solid-svg-icons";
@@ -49,11 +50,24 @@ export class TreeView extends React.Component<
     let depth = this.props.depth || 0;
 
     let backgroundColor = "";
+
     if (tree.error) {
       backgroundColor = ERROR_BACKGROUND_COLOR;
     }
-    if (this.props.selected == tree) {
-      backgroundColor = "#dedede";
+
+
+    if (tree.color.isDefault()) {
+        if (this.props.selected == tree) {
+            backgroundColor = tree.color.hex;
+        } else {
+            backgroundColor = Color.white().hex;
+        }
+    } else {
+        if (this.props.selected == tree) {
+            backgroundColor = tree.color.hex
+        } else {
+            backgroundColor = tree.color.hexLighter();
+        }
     }
 
     if (tree.children.length > 0) {
@@ -83,7 +97,9 @@ export class TreeView extends React.Component<
                 icon={this.state.open ? faCaretDown : faCaretRight}
               />
             </span>
-            <span>{tree.label}</span>
+            <span title={`Byte ${tree.range.offset()} to ${tree.range.offset() + tree.range.size()}`}>
+                {tree.label}
+            </span>
           </div>
 
           {this.state.open &&
@@ -101,7 +117,7 @@ export class TreeView extends React.Component<
       );
     } else {
       return (
-        <div
+        <div title={`Byte ${tree.range.offset()} to ${tree.range.offset() + tree.range.size()}`}
           style={{
             backgroundColor,
             paddingLeft: "5px"


### PR DESCRIPTION
- Add color edition for each Tree (Setup on PNG as example) - fifth argument of Tree `constructor` or `withColor(Color.red())` method
- Show byte range start/end in tooltip for each Tree labels
- Show selected element in bold
<img width="1148" alt="Capture d’écran 2023-06-22 à 18 52 32" src="https://github.com/rameshvarun/binary-inspector/assets/3283866/6b93152a-021d-4d25-aa0a-597a8a4e60d0">
